### PR TITLE
Доработал хелпер develop.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ stages:
 jobs:
   include:
     - language: generic
+      env: NAME="PHP tests"
       stage: testing
       sudo: required
       services:
@@ -21,6 +22,7 @@ jobs:
         - ./develop.sh run --rm php php vendor/bin/phpunit
 
     - stage: testing
+      env: NAME="Angular tests"
       language: node_js
       sudo: required
       node_js:
@@ -34,9 +36,10 @@ jobs:
         - cd front
         - npm install
       script:
-        - node_modules/.bin/ng test --single-run --browsers=ChromeHeadless --progress=false
+        - node_modules/.bin/ng test --single-run --browsers ChromeHeadless --progress false --reporters dots
 
     - stage: code-quality
+      env: NAME="Angular lint"
       language: node_js
       node_js:
         - "8"

--- a/develop.sh
+++ b/develop.sh
@@ -6,7 +6,24 @@ fi
 
 export REDIS_PASSWORD=${REDIS_PASSWORD:-app}
 
-COMMAND="docker-compose -f docker-compose.base.yml $@"
+case "$1" in
+    "art")
+        shift 1
+        COMMAND="run --rm php php artisan $@"
+    ;;
+    "composer")
+        shift 1
+        COMMAND="run --rm php composer $@"
+    ;;
+    "")
+        COMMAND="ps"
+    ;;
+    *)
+        COMMAND="$@"
+    ;;
+esac
+
+COMMAND="docker-compose -f docker-compose.base.yml ${COMMAND}"
 
 echo ${COMMAND};
 


### PR DESCRIPTION
Добавил команды для более удобного запуска:
* Artisan-команд: `./develop.sh art migrate`
* Composer: `./develop.sh composer install`
* По умолчанию отображается список запущенных контейнеров: `./develop.sh`

Если указаны параметры и первый из нах не `art` и не `composer`, то выполняется docker-compose с указанными параметрами